### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :show]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   
   def index
     @items = Item.includes(:user).order('created_at DESC')

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new ]
+  before_action :authenticate_user!, only: [:index, :show]
   
   def index
     @items = Item.includes(:user).order('created_at DESC')
@@ -16,6 +16,14 @@ class ItemsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def show
+    @item = Item.find(params[:id])
+  end
+
+  def destroy
+    redirect_to root_path if item.destroy
   end
 
   private

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
       <% if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(item.id) do %>
+        <%= link_to item_path(item.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,9 +10,9 @@
     <div class='item-img-content'>
       <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合はsold out %>
-      <div class='sold-out'>
-        <span>Sold Out!!</span>
-      </div>
+      <%#<div class='sold-out'>
+      <%#  <span>Sold Out!!</span>
+      <%#</div>
       <%# //商品が売れている場合はsold out %>
     </div>
     <div class="item-price-box">
@@ -24,13 +24,12 @@
       </span>
     </div>
 
-  
   <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
         <%= link_to '商品の編集', "#" , method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-    <% elsif @item.purchase.blank? %>
+        <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+    <% elsif '商品が出品中かどうか' %>
         <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -5,42 +5,38 @@
   <div class="item-box">
     <h2 class="name">
       <%= @item.name %>
+
     </h2>
     <div class='item-img-content'>
-      <%= image_tag @item.image ,class:"item-box-img" %>
-      
-    <% if @item.purchase.present? %>
+      <%= image_tag @item.image ,class:"item-box-img" if @item.image.attached? %>
+      <%# 商品が売れている場合はsold out %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
-    <% end %>
-      
+      <%# //商品が売れている場合はsold out %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= @item.price %>
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= @item.postage.name %>
+        <%= @item.shipping_charge.name %>
       </span>
     </div>
 
   
   <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-      <% if @item.purchase.blank? %>
-        <%= link_to '商品の編集',  edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', "#" , method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
         <%= link_to '削除', item_path(@item.id), method: :delete, class:'item-destroy' %>
-      <% end %>
     <% elsif @item.purchase.blank? %>
-      <%= link_to '購入画面に進む', item_purchases_path(@item.id) ,class:"item-red-btn"%>
+        <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
   <% end %>
     
-
     <div class="item-explain-box">
-      <span><%= @item.explanation %></span>
+      <span><%= @item.text %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -58,15 +54,15 @@
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.postage.name %></td>
+          <td class="detail-value"><%= @item.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.prefecture.name %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.handling.name %></td>
+          <td class="detail-value"><%= @item.delivery_time.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do  
   devise_for :users
   root to: 'items#index'  
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 end


### PR DESCRIPTION
# What
商品詳細表示機能の実装

# Why
商品の詳細を表示させる機能を実装するため。

【機能確認】
・商品詳細機能へのアクセス(ログイン状態の出品者)
    →編集・削除ボタン」が表示される
　→商品出品時に登録した情報の表示
　https://gyazo.com/e65f9f0b4b1918ae80d64eab479076f9

・商品詳細機能へのアクセス(ログイン状態の非出品者)
　→購入ボタンの表示
　https://gyazo.com/1401e182c55668b90e3c0b020646195f

・ログアウト状態のユーザー
　→「編集・削除・購入画面に進むボタン」が表示されない
　https://gyazo.com/6c988344e5d1d97ce35b48c0a4b9106e

レビュー、宜しくお願いいたします。